### PR TITLE
Mark current api as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * [Passenger railway operators static timetable, published anually, XML format](https://data.gov.ro/organization/sc-informatica-feroviara-sa)
 * [Iași urban transit: GPS positions in real-time, JSON](https://gps.sctpiasi.ro/json)
 * [Bucharest urban transit: lines, stations, departures in real time, timetables, GPS positions](https://info.stbsa.ro/rp/api/lines/)
+  ⚠️ No longer updated. Can still be used for real time vehicle position on lines existing prior to 07/06/2023 but should not be used for things like schedules.
 <details>
   <summary>Details</summary>
   


### PR DESCRIPTION
Since the release of the v2 api (https://info.stbsa.ro/v2/api/web/lines) things like schedules and stations are no longer updated on the v1 of the api.  Since v2 of the api can't really be used I suggest keeping the v1 api in the list but mark it as unmaintained as it still can be used for real-time vehicle positions on lines created prior to v2's implementation.